### PR TITLE
use typedefs to SharedPtr types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   matrix:
     - ROS_DISTRO="indigo"  ROS_REPO=ros
     - ROS_DISTRO="jade"  ROS_REPO=ros
-    - ROS_DISTRO="kinetic"  ROS_REPO=ros
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -42,6 +42,7 @@
 #include <vector>
 #include <utility>
 #include <urdf_model/model.h>
+#include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
 
 /// Main namespace
@@ -269,6 +270,9 @@ private:
   std::vector<DisabledCollision> disabled_collisions_;
   std::vector<PassiveJoint>      passive_joints_;
 };
+typedef boost::shared_ptr<Model> ModelSharedPtr;
+typedef boost::shared_ptr<const Model> ModelConstSharedPtr;
+
 
 }
 #endif

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -45,6 +45,11 @@
 #include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
 
+namespace urdf
+{
+typedef boost::shared_ptr<const ::urdf::Link> LinkConstSharedPtr;
+}
+
 /// Main namespace
 namespace srdf
 {

--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -37,8 +37,6 @@
 #ifndef _SRDFDOM_SRDF_WRITER_
 #define _SRDFDOM_SRDF_WRITER_
 
-
-#include <boost/shared_ptr.hpp>
 #include <srdfdom/model.h> // use their struct datastructures
 
 namespace srdf
@@ -175,7 +173,7 @@ public:
   std::vector<srdf::Model::PassiveJoint>      passive_joints_;
 
   // Store the SRDF Model for updating the kinematic_model
-  boost::shared_ptr<srdf::Model>                 srdf_model_;
+  srdf::ModelSharedPtr                        srdf_model_;
 
   // Robot name
   std::string robot_name_;
@@ -185,8 +183,6 @@ public:
 // ******************************************************************************************
 // Typedef
 // ******************************************************************************************
-
-/// Create a shared pointer for passing this data object between widgets
 typedef boost::shared_ptr<SRDFWriter> SRDFWriterPtr;
 
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -179,7 +179,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
         continue;
       }
       bool found = false;
-      boost::shared_ptr<const urdf::Link> l = urdf_model.getLink(tip_str);
+      urdf::LinkConstSharedPtr l = urdf_model.getLink(tip_str);
       std::set<std::string> seen;
       while (!found && l)
       {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -40,6 +40,11 @@
 #include <stdexcept>
 #include <boost/lexical_cast.hpp>
 
+namespace urdf
+{
+typedef boost::shared_ptr<const ::urdf::ModelInterface> ModelInterfaceSharedPtr;
+}
+
 #define EXPECT_TRUE(arg) if (!(arg)) throw std::runtime_error("Assertion failed at line " + boost::lexical_cast<std::string>(__LINE__))
 
 #ifndef TEST_RESOURCE_LOCATION

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -46,7 +46,7 @@
 #  define TEST_RESOURCE_LOCATION "."
 #endif
 
-boost::shared_ptr<urdf::ModelInterface> loadURDF(const std::string& filename)
+urdf::ModelInterfaceSharedPtr loadURDF(const std::string& filename)
 {
   // get the entire file
   std::string xml_string;
@@ -65,14 +65,14 @@ boost::shared_ptr<urdf::ModelInterface> loadURDF(const std::string& filename)
   else
   {
     throw std::runtime_error("Could not open file " + filename + " for parsing.");
-    return boost::shared_ptr<urdf::ModelInterface>();
+    return urdf::ModelInterfaceSharedPtr();
   }
 }
 
 void testSimple(void)
 {
   srdf::Model s;
-  boost::shared_ptr<urdf::ModelInterface> u = loadURDF(std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.urdf");
+  urdf::ModelInterfaceSharedPtr u = loadURDF(std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.urdf");
   EXPECT_TRUE(u != NULL);
   
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.1.srdf"));
@@ -100,7 +100,7 @@ void testSimple(void)
 void testComplex(void)
 {
   srdf::Model s;
-  boost::shared_ptr<urdf::ModelInterface> u = loadURDF(std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.urdf");
+  urdf::ModelInterfaceSharedPtr u = loadURDF(std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.urdf");
   EXPECT_TRUE(u != NULL);
 
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.3.srdf"));


### PR DESCRIPTION
urdfdom switched to std::shared_ptr in release 1.0. To be prepared for this transition, we use appropriate typedefs here too. Addresses #17.
