### PR TITLE
require version 0.4 of urdfdom_headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 find_package(console_bridge REQUIRED)
-find_package(urdfdom_headers REQUIRED)
+find_package(urdfdom_headers 0.4 REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules urdfdom_py)
 

--- a/package.xml
+++ b/package.xml
@@ -16,13 +16,13 @@
   <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
-  <build_depend>liburdfdom-headers-dev</build_depend>
+  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
   <build_depend>urdfdom_py</build_depend>
   <build_depend>tinyxml</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
-  <run_depend>liburdfdom-headers-dev</run_depend>
+  <run_depend version_gte="0.4">liburdfdom-headers-dev</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>urdfdom_py</run_depend>
 


### PR DESCRIPTION
Correctly denote the revision of urdfdom_headers required for this branch.
