### PR TITLE
urdfdom compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 find_package(console_bridge REQUIRED)
-find_package(urdfdom_headers 0.4 REQUIRED)
+find_package(urdfdom_headers REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules urdfdom_py)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,19 +16,10 @@ link_directories(${catkin_LIBRARY_DIRS})
 
 
 ### Maintain compatibility to old urdfdom_headers (version < 4.0)
-# check for existence of type urdf::LinkSharedPtr
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-#include <urdf_model/model.h>
-
-int main(int argc, char** argv)
-{
-  urdf::LinkSharedPtr l;
-  return 0;
-}
-" HAVE_URDFDOM_4)
-if(NOT HAVE_URDFDOM_4)
-  set(HAVE_URDFDOM_4 "0")
+if( "0.4.0" VERSION_GREATER "${urdfdom_headers_VERSION}")
+  set(HAVE_URDFDOM_4 0)
+else()
+  set(HAVE_URDFDOM_4 1)
 endif()
 set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdfdom_compatibility.h")
 include_directories("${CATKIN_DEVEL_PREFIX}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,32 @@ find_package(TinyXML REQUIRED)
 include_directories(include ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
+
+### Maintain compatibility to old urdfdom_headers (version < 4.0)
+# check for existence of type urdf::LinkSharedPtr
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+#include <urdf_model/model.h>
+
+int main(int argc, char** argv)
+{
+  urdf::LinkSharedPtr l;
+  return 0;
+}
+" HAVE_URDFDOM_4)
+if(NOT HAVE_URDFDOM_4)
+  set(HAVE_URDFDOM_4 "0")
+endif()
+set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdfdom_compatibility.h")
+include_directories("${CATKIN_DEVEL_PREFIX}/include")
+configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
+
+
 catkin_python_setup()
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include ${TinyXML_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${TinyXML_INCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include
   DEPENDS console_bridge urdfdom_headers urdfdom_py
 )
 
@@ -36,6 +57,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
 )
+install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 install(PROGRAMS 
   scripts/display_srdf

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -42,6 +42,7 @@
 #include <vector>
 #include <utility>
 #include <urdf_model/model.h>
+#include <srdfdom/urdfdom_compatibility.h>
 #include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
 

--- a/package.xml
+++ b/package.xml
@@ -16,13 +16,13 @@
   <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
-  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
+  <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>urdfdom_py</build_depend>
   <build_depend>tinyxml</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
-  <run_depend version_gte="0.4">liburdfdom-headers-dev</run_depend>
+  <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>urdfdom_py</run_depend>
 

--- a/urdfdom_compatibility.h.in
+++ b/urdfdom_compatibility.h.in
@@ -1,0 +1,78 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, CITEC, Bielefeld University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Robert Haschke */
+
+#ifndef SRDF_URDFDOM_COMPATIBILITY_
+#define SRDF_URDFDOM_COMPATIBILITY_
+
+// This code is only activated when urdfdom's type forwards were not available
+// at cmake configuration time
+
+#if @HAVE_URDFDOM_4@ == 0
+
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
+
+#define URDF_TYPEDEF_CLASS_POINTER(Class) \
+class Class; \
+typedef boost::shared_ptr<Class> Class##SharedPtr; \
+typedef boost::shared_ptr<const Class> Class##ConstSharedPtr; \
+typedef boost::weak_ptr<Class> Class##WeakPtr
+
+namespace urdf {
+URDF_TYPEDEF_CLASS_POINTER(Box);
+URDF_TYPEDEF_CLASS_POINTER(Collision);
+URDF_TYPEDEF_CLASS_POINTER(Cylinder);
+URDF_TYPEDEF_CLASS_POINTER(Geometry);
+URDF_TYPEDEF_CLASS_POINTER(Inertial);
+
+URDF_TYPEDEF_CLASS_POINTER(Joint);
+URDF_TYPEDEF_CLASS_POINTER(JointCalibration);
+URDF_TYPEDEF_CLASS_POINTER(JointDynamics);
+URDF_TYPEDEF_CLASS_POINTER(JointLimits);
+URDF_TYPEDEF_CLASS_POINTER(JointMimic);
+URDF_TYPEDEF_CLASS_POINTER(JointSafety);
+
+URDF_TYPEDEF_CLASS_POINTER(Link);
+URDF_TYPEDEF_CLASS_POINTER(Material);
+URDF_TYPEDEF_CLASS_POINTER(Mesh);
+URDF_TYPEDEF_CLASS_POINTER(Sphere);
+URDF_TYPEDEF_CLASS_POINTER(Visual);
+}
+
+#undef URDF_TYPEDEF_CLASS_POINTER
+
+#endif
+#endif // SRDF_URDFDOM_COMPATIBILITY_


### PR DESCRIPTION
Attempt to solve #23.
During configuration time, cmake will check for the existence of urdfdom's typedefs. If not available an appropriate compatibility header will be activated.

We will need a similar mechanism for #209 and we might want to remove this hack if Wily runs out of support... A lot of effort for supporting the nearly dead Wily distribution.
