### PR TITLE
readd boost/shared_ptr.hpp include

### DIFF
--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -37,6 +37,7 @@
 #ifndef _SRDFDOM_SRDF_WRITER_
 #define _SRDFDOM_SRDF_WRITER_
 
+#include <boost/shared_ptr.hpp>
 #include <srdfdom/model.h> // use their struct datastructures
 
 namespace srdf


### PR DESCRIPTION
The template is used at the bottom of the file, so the header should be included explicitly.

See also https://github.com/ros-planning/srdfdom/pull/18/commits/9b2e9fb85740517a20ce872f13de6f70a40ef33b#r78252532
