### PR TITLE
[Indigo] cleanup urdfdom compatibility (cherry-picking #27)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,14 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 find_package(console_bridge REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS cmake_modules urdfdom_py)
+find_package(catkin REQUIRED COMPONENTS cmake_modules urdf urdfdom_py)
 
 find_package(TinyXML REQUIRED)
 
 include_directories(include ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
+
+add_compile_options(-std=c++11)
 
 catkin_python_setup()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ find_package(TinyXML REQUIRED)
 include_directories(include ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-add_compile_options(-std=c++11)
-
 catkin_python_setup()
 
 catkin_package(

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -41,7 +41,7 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <urdf_model/model.h>
+#include <urdf/model.h> // TODO: replace with urdf_model/types.h in Lunar
 #include <boost/shared_ptr.hpp>
 #include <tinyxml.h>
 

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
+  <build_depend>urdf</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>urdfdom_py</build_depend>
   <build_depend>tinyxml</build_depend>


### PR DESCRIPTION
Just noticed that https://github.com/ros/robot_model/pull/160, which https://github.com/ros-planning/srdfdom/pull/27 relies on, is backported to Indigo. So I thought https://github.com/ros-planning/srdfdom/pull/27 can also be ported back to Indigo.
Please review @v4hn @rhaschke 