### PR TITLE
Change logError to CONSOLE_BRIDGE_logError & logWarn to CONSOLE_BRIDG…

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -54,27 +54,27 @@ void srdf::Model::loadVirtualJoints(const urdf::ModelInterface &urdf_model, TiXm
     const char *type = vj_xml->Attribute("type");
     if (!jname)
     {
-      logError("Name of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Name of virtual joint is not specified");
       continue;
     }
     if (!child)
     {
-      logError("Child link of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Child link of virtual joint is not specified");
       continue;
     }
     if (!urdf_model.getLink(boost::trim_copy(std::string(child))))
     {
-      logError("Virtual joint does not attach to a link on the robot (link '%s' is not known)", child);
+      CONSOLE_BRIDGE_logError("Virtual joint does not attach to a link on the robot (link '%s' is not known)", child);
       continue;
     }
     if (!parent)
     {
-      logError("Parent frame of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Parent frame of virtual joint is not specified");
       continue;
     }
     if (!type)
     {
-      logError("Type of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Type of virtual joint is not specified");
       continue;
     }
     VirtualJoint vj;
@@ -82,7 +82,7 @@ void srdf::Model::loadVirtualJoints(const urdf::ModelInterface &urdf_model, TiXm
     std::transform(vj.type_.begin(), vj.type_.end(), vj.type_.begin(), ::tolower);
     if (vj.type_ != "planar" && vj.type_ != "floating" && vj.type_ != "fixed")
     {
-      logError("Unknown type of joint: '%s'. Assuming 'fixed' instead. Other known types are 'planar' and 'floating'.", type);
+      CONSOLE_BRIDGE_logError("Unknown type of joint: '%s'. Assuming 'fixed' instead. Other known types are 'planar' and 'floating'.", type);
       vj.type_ = "fixed";
     }
     vj.name_ = std::string(jname); boost::trim(vj.name_);        
@@ -99,7 +99,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
     const char *gname = group_xml->Attribute("name");
     if (!gname)
     {
-      logError("Group name not specified");
+      CONSOLE_BRIDGE_logError("Group name not specified");
       continue;
     }
     Group g;
@@ -111,13 +111,13 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       const char *lname = link_xml->Attribute("name");
       if (!lname)
       {
-        logError("Link name not specified");
+        CONSOLE_BRIDGE_logError("Link name not specified");
         continue;
       }
       std::string lname_str = boost::trim_copy(std::string(lname));
       if (!urdf_model.getLink(lname_str))
       {
-        logError("Link '%s' declared as part of group '%s' is not known to the URDF", lname, gname);
+        CONSOLE_BRIDGE_logError("Link '%s' declared as part of group '%s' is not known to the URDF", lname, gname);
         continue;
       }
       g.links_.push_back(lname_str);
@@ -129,7 +129,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       const char *jname = joint_xml->Attribute("name");
       if (!jname)
       {
-        logError("Joint name not specified");
+        CONSOLE_BRIDGE_logError("Joint name not specified");
         continue;
       }
       std::string jname_str = boost::trim_copy(std::string(jname));
@@ -144,7 +144,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
           }
         if (missing)
         {
-          logError("Joint '%s' declared as part of group '%s' is not known to the URDF", jname, gname);
+          CONSOLE_BRIDGE_logError("Joint '%s' declared as part of group '%s' is not known to the URDF", jname, gname);
           continue;
         }
       }
@@ -158,24 +158,24 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       const char *tip = chain_xml->Attribute("tip_link");
       if (!base)
       {
-        logError("Base link name not specified for chain");
+        CONSOLE_BRIDGE_logError("Base link name not specified for chain");
         continue;
       }
       if (!tip)
       {
-        logError("Tip link name not specified for chain");
+        CONSOLE_BRIDGE_logError("Tip link name not specified for chain");
         continue;
       }
       std::string base_str = boost::trim_copy(std::string(base));
       std::string tip_str = boost::trim_copy(std::string(tip));
       if (!urdf_model.getLink(base_str))
       {
-        logError("Link '%s' declared as part of a chain in group '%s' is not known to the URDF", base, gname);
+        CONSOLE_BRIDGE_logError("Link '%s' declared as part of a chain in group '%s' is not known to the URDF", base, gname);
         continue;
       }
       if (!urdf_model.getLink(tip_str))
       {
-        logError("Link '%s' declared as part of a chain in group '%s' is not known to the URDF", tip, gname);
+        CONSOLE_BRIDGE_logError("Link '%s' declared as part of a chain in group '%s' is not known to the URDF", tip, gname);
         continue;
       }
       bool found = false;
@@ -203,7 +203,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       if (found)
         g.chains_.push_back(std::make_pair(base_str, tip_str));
       else
-        logError("Links '%s' and '%s' do not form a chain. Not included in group '%s'", base, tip, gname);
+        CONSOLE_BRIDGE_logError("Links '%s' and '%s' do not form a chain. Not included in group '%s'", base, tip, gname);
     }
     
     // get the subgroups in the groups
@@ -212,13 +212,13 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       const char *sub = subg_xml->Attribute("name");
       if (!sub)
       {
-        logError("Group name not specified when included as subgroup");
+        CONSOLE_BRIDGE_logError("Group name not specified when included as subgroup");
         continue;
       }
       g.subgroups_.push_back(boost::trim_copy(std::string(sub)));
     }
     if (g.links_.empty() && g.joints_.empty() && g.chains_.empty() && g.subgroups_.empty())
-      logWarn("Group '%s' is empty.", gname);
+      CONSOLE_BRIDGE_logWarn("Group '%s' is empty.", gname);
     groups_.push_back(g);
   }
   
@@ -260,7 +260,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface &urdf_model, TiXmlElemen
       if (known_groups.find(groups_[i].name_) != known_groups.end())
         correct.push_back(groups_[i]);
       else
-        logError("Group '%s' has unsatisfied subgroups", groups_[i].name_.c_str());
+        CONSOLE_BRIDGE_logError("Group '%s' has unsatisfied subgroups", groups_[i].name_.c_str());
     groups_.swap(correct);
   }
 }
@@ -273,12 +273,12 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface &urdf_model, TiXmlE
     const char *gname = gstate_xml->Attribute("group");
     if (!sname)
     {
-      logError("Name of group state is not specified");
+      CONSOLE_BRIDGE_logError("Name of group state is not specified");
       continue;
     }
     if (!gname)
     {
-      logError("Name of group for state '%s' is not specified", sname);
+      CONSOLE_BRIDGE_logError("Name of group for state '%s' is not specified", sname);
       continue;
     }
     
@@ -295,7 +295,7 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface &urdf_model, TiXmlE
       }
     if (!found)
     {
-      logError("Group state '%s' specified for group '%s', but that group is not known", sname, gname);
+      CONSOLE_BRIDGE_logError("Group state '%s' specified for group '%s', but that group is not known", sname, gname);
       continue;
     }
     
@@ -306,12 +306,12 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface &urdf_model, TiXmlE
       const char *jval = joint_xml->Attribute("value");
       if (!jname)
       {
-        logError("Joint name not specified in group state '%s'", sname);
+        CONSOLE_BRIDGE_logError("Joint name not specified in group state '%s'", sname);
         continue;
       }
       if (!jval)
       {
-        logError("Joint name not specified for joint '%s' in group state '%s'", jname, sname);
+        CONSOLE_BRIDGE_logError("Joint name not specified for joint '%s' in group state '%s'", jname, sname);
         continue;
       }
       std::string jname_str = boost::trim_copy(std::string(jname));
@@ -326,7 +326,7 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface &urdf_model, TiXmlE
           }
         if (missing)
         {
-          logError("Joint '%s' declared as part of group state '%s' is not known to the URDF", jname, sname);
+          CONSOLE_BRIDGE_logError("Joint '%s' declared as part of group state '%s' is not known to the URDF", jname, sname);
           continue;
         }
       }
@@ -342,11 +342,11 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface &urdf_model, TiXmlE
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Unable to parse joint value '%s'", jval);
+        CONSOLE_BRIDGE_logError("Unable to parse joint value '%s'", jval);
       }
       
       if (gs.joint_values_.empty())
-        logError("Unable to parse joint value ('%s') for joint '%s' in group state '%s'", jval, jname, sname);
+        CONSOLE_BRIDGE_logError("Unable to parse joint value ('%s') for joint '%s' in group state '%s'", jval, jname, sname);
     }
     group_states_.push_back(gs);
   }
@@ -362,12 +362,12 @@ void srdf::Model::loadEndEffectors(const urdf::ModelInterface &urdf_model, TiXml
     const char *parent_group = eef_xml->Attribute("parent_group");
     if (!ename)
     {
-      logError("Name of end effector is not specified");
+      CONSOLE_BRIDGE_logError("Name of end effector is not specified");
       continue;
     }
     if (!gname)
     {
-      logError("Group not specified for end effector '%s'", ename);
+      CONSOLE_BRIDGE_logError("Group not specified for end effector '%s'", ename);
       continue;
     }
     EndEffector e;
@@ -382,18 +382,18 @@ void srdf::Model::loadEndEffectors(const urdf::ModelInterface &urdf_model, TiXml
       }
     if (!found)
     {
-      logError("End effector '%s' specified for group '%s', but that group is not known", ename, gname);
+      CONSOLE_BRIDGE_logError("End effector '%s' specified for group '%s', but that group is not known", ename, gname);
       continue;
     }
     if (!parent)
     {
-      logError("Parent link not specified for end effector '%s'", ename);
+      CONSOLE_BRIDGE_logError("Parent link not specified for end effector '%s'", ename);
       continue;
     }
     e.parent_link_ = std::string(parent); boost::trim(e.parent_link_);
     if (!urdf_model.getLink(e.parent_link_))
     {
-      logError("Link '%s' specified as parent for end effector '%s' is not known to the URDF", parent, ename);
+      CONSOLE_BRIDGE_logError("Link '%s' specified as parent for end effector '%s' is not known to the URDF", parent, ename);
       continue;
     }
     if (parent_group)
@@ -412,7 +412,7 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface &urdf_
     const char *link_name = cslink_xml->Attribute("link");
     if (!link_name)
     {
-      logError("Name of link is not specified in link_collision_spheres");
+      CONSOLE_BRIDGE_logError("Name of link is not specified in link_collision_spheres");
       continue;
     }
     
@@ -420,7 +420,7 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface &urdf_
     link_spheres.link_ = boost::trim_copy(std::string(link_name));
     if (!urdf_model.getLink(link_spheres.link_))
     {
-      logError("Link '%s' is not known to URDF.", link_name);
+      CONSOLE_BRIDGE_logError("Link '%s' is not known to URDF.", link_name);
       continue;
     }
     
@@ -433,7 +433,7 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface &urdf_
       const char *s_r = sphere_xml->Attribute("radius");
       if (!s_center || !s_r)
       {
-        logError("Link collision sphere %d for link '%s' does not have both center and radius.", cnt, link_name);
+        CONSOLE_BRIDGE_logError("Link collision sphere %d for link '%s' does not have both center and radius.", cnt, link_name);
         continue;
       }
 
@@ -447,12 +447,12 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface &urdf_
       }
       catch (std::stringstream::failure &e)
       {
-        logError("Link collision sphere %d for link '%s' has bad center attribute value.", cnt, link_name);
+        CONSOLE_BRIDGE_logError("Link collision sphere %d for link '%s' has bad center attribute value.", cnt, link_name);
         continue;
       }
       catch (boost::bad_lexical_cast &e)
       {
-        logError("Link collision sphere %d for link '%s' has bad radius attribute value.", cnt, link_name);
+        CONSOLE_BRIDGE_logError("Link collision sphere %d for link '%s' has bad radius attribute value.", cnt, link_name);
         continue;
       }
 
@@ -499,7 +499,7 @@ void srdf::Model::loadDisabledCollisions(const urdf::ModelInterface &urdf_model,
     const char *link2 = c_xml->Attribute("link2");
     if (!link1 || !link2)
     {
-      logError("A pair of links needs to be specified to disable collisions");
+      CONSOLE_BRIDGE_logError("A pair of links needs to be specified to disable collisions");
       continue;
     }
     DisabledCollision dc;
@@ -507,12 +507,12 @@ void srdf::Model::loadDisabledCollisions(const urdf::ModelInterface &urdf_model,
     dc.link2_ = boost::trim_copy(std::string(link2));
     if (!urdf_model.getLink(dc.link1_))
     {
-      logWarn("Link '%s' is not known to URDF. Cannot disable collisons.", link1);
+      CONSOLE_BRIDGE_logWarn("Link '%s' is not known to URDF. Cannot disable collisons.", link1);
       continue;
     }
     if (!urdf_model.getLink(dc.link2_))
     {
-      logWarn("Link '%s' is not known to URDF. Cannot disable collisons.", link2);
+      CONSOLE_BRIDGE_logWarn("Link '%s' is not known to URDF. Cannot disable collisons.", link2);
       continue;
     }
     const char *reason = c_xml->Attribute("reason");
@@ -529,7 +529,7 @@ void srdf::Model::loadPassiveJoints(const urdf::ModelInterface &urdf_model, TiXm
     const char *name = c_xml->Attribute("name");
     if (!name)
     {
-      logError("No name specified for passive joint. Ignoring.");
+      CONSOLE_BRIDGE_logError("No name specified for passive joint. Ignoring.");
       continue;
     }
     PassiveJoint pj;
@@ -543,7 +543,7 @@ void srdf::Model::loadPassiveJoints(const urdf::ModelInterface &urdf_model, TiXm
     
     if (!vjoint && !urdf_model.getJoint(pj.name_))
     {
-      logError("Joint '%s' marked as passive is not known to the URDF. Ignoring.", name);
+      CONSOLE_BRIDGE_logError("Joint '%s' marked as passive is not known to the URDF. Ignoring.", name);
       continue;
     }
     passive_joints_.push_back(pj);
@@ -555,19 +555,19 @@ bool srdf::Model::initXml(const urdf::ModelInterface &urdf_model, TiXmlElement *
   clear();
   if (!robot_xml || robot_xml->ValueStr() != "robot")
   {
-    logError("Could not find the 'robot' element in the xml file");
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file");
     return false;
   }
   
   // get the robot name
   const char *name = robot_xml->Attribute("name");
   if (!name)
-    logError("No name given for the robot.");
+    CONSOLE_BRIDGE_logError("No name given for the robot.");
   else
   {
     name_ = std::string(name); boost::trim(name_);
     if (name_ != urdf_model.getName())
-      logError("Semantic description is not specified for the same robot as the URDF");
+      CONSOLE_BRIDGE_logError("Semantic description is not specified for the same robot as the URDF");
   }
   
   loadVirtualJoints(urdf_model, robot_xml);
@@ -586,7 +586,7 @@ bool srdf::Model::initXml(const urdf::ModelInterface &urdf_model, TiXmlDocument 
   TiXmlElement *robot_xml = xml ? xml->FirstChildElement("robot") : NULL;
   if (!robot_xml)
   {
-    logError("Could not find the 'robot' element in the xml file");
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file");
     return false;
   }
   return initXml(urdf_model, robot_xml);
@@ -611,7 +611,7 @@ bool srdf::Model::initFile(const urdf::ModelInterface &urdf_model, const std::st
   }
   else
   {
-    logError("Could not open file [%s] for parsing.", filename.c_str());
+    CONSOLE_BRIDGE_logError("Could not open file [%s] for parsing.", filename.c_str());
     return false;
   }
 }


### PR DESCRIPTION
I was getting build errors on kinetic due to logWarn - Changing the call to CONSOLE_BRIDGE_logError fixed the issue. Thought Id share.

Error experienced:

 error: ‘logError’ was not declared in this scope
       logError("Name of virtual joint is not specified");

This issue is what I referenced to solve the problem:
https://github.com/ros/ros-overlay/issues/509