### PR TITLE
Run clang-format test on melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   matrix:
-    - ROS_DISTRO=kinetic ROS_REPO=ros  TEST=clang-format
+    - ROS_DISTRO=melodic ROS_REPO=ros  TEST=clang-format
     - ROS_DISTRO=melodic ROS_REPO=ros
 
 before_script:


### PR DESCRIPTION
@rhaschke this should work now that https://github.com/ros-planning/moveit_ci/pull/39 has been merged

The problem was that clang-format-3.8 exists on 16.04, but not 18.04. clang-format-3.9 exists on both 16.04 and 18.04.

Will be good to see whether tests pass now.