### PR TITLE
fix catkin_lint issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ notifications:
     recipients:
       - 130s@2000.jukuin.keio.ac.jp
 env:
+  global:
+    - ROS_DISTRO=melodic
+    - ROS_REPO=ros
   matrix:
-    - ROS_DISTRO=melodic ROS_REPO=ros  TEST=clang-format
-    - ROS_DISTRO=melodic ROS_REPO=ros
+    - TEST="clang-format, catkin_lint"
+    - ROS_DISTRO=melodic
 
 before_script:
-  - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+  - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
+
 script:
-  - source .moveit_ci/travis.sh
+  - .moveit_ci/travis.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,14 @@ find_package(catkin REQUIRED COMPONENTS cmake_modules urdf urdfdom_py)
 
 find_package(TinyXML REQUIRED)
 
-include_directories(include ${Boost_INCLUDE_DIR} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+include_directories(
+  include
+  ${Boost_INCLUDE_DIR}
+  ${TinyXML_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${console_bridge_INCLUDE_DIRS}
+  ${urdfdom_headers_INCLUDE_DIRS}
+  )
 
 add_compile_options(-std=c++11)
 
@@ -19,8 +25,8 @@ catkin_python_setup()
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include ${TinyXML_INCLUDE_DIRS}
-  DEPENDS console_bridge urdfdom_headers urdfdom_py
+  INCLUDE_DIRS include
+  DEPENDS TinyXML console_bridge urdfdom_headers
 )
 
 add_library(${PROJECT_NAME} 


### PR DESCRIPTION
Fix catkin issues:
```bash
$ catkin_lint .
srdfdom: CMakeLists.txt(20): error: catkin_package() lists 'urdfdom_py' as system package but it is not
srdfdom: CMakeLists.txt(20): error: catkin_package() exports non-package include path
srdfdom: CMakeLists.txt(14): warning: use of link_directories() is strongly discouraged
```
and enable `catkin_lint` checker.