### PR TITLE
Make srdf::Model member variables public

### DIFF
--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -259,6 +259,7 @@ private:
   void loadDisabledCollisions(const urdf::ModelInterface& urdf_model, TiXmlElement* robot_xml);
   void loadPassiveJoints(const urdf::ModelInterface& urdf_model, TiXmlElement* robot_xml);
 
+public:
   std::string name_;
   std::vector<Group> groups_;
   std::vector<GroupState> group_states_;


### PR DESCRIPTION
I want to postprocess the `srdf::Model` instance after reading from the XML, to expand the `chain` and `subgroup` elements into their corresponding `joint` and `link`s inside each group. Ideally, I'd like to do this _in-place_ in the existing `srdf::Model`, but I'm currently unable to do that since `srdf::Model::groups_` is a private member.

Would you be open to make the members of `srdf::Model` public (similar to how the members of [`urdf::ModelInstance`](https://github.com/ros/urdfdom_headers/blob/00c1c9c231e46b2300d04073ad696521758fa45c/urdf_model/include/urdf_model/model.h) are public as well?). I can use a [workaround](https://github.com/hliberacki/cpp-member-accessor) if needed, but I'd rather not.

I'm unsure whether this means breaking ABI compatibility, and whether you care about that at all. I quickly tried to add a ABI test but failed so far.