### PR TITLE
Remove non-exist ROS2 dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
   <build_depend>boost</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>urdfdom_headers</build_depend>
-  <build_depend>urdfdom_py</build_depend>
   <build_depend>tinyxml2_vendor</build_depend>
   <build_depend>urdf</build_depend>
 
@@ -26,7 +25,6 @@
   <exec_depend>boost</exec_depend>
   <exec_depend>libconsole-bridge-dev</exec_depend>
   <exec_depend>tinyxml2_vendor</exec_depend>
-  <exec_depend>urdfdom_py</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <export>


### PR DESCRIPTION
There is no urdfdom_py in ROS2, so these depends hinder rosdep install usage, and seem unnecessary for srdfdom to compile and run in ROS2.