### PR TITLE
Noetic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ catkin_package(
   DEPENDS TinyXML console_bridge urdfdom_headers
 )
 
-add_library(${PROJECT_NAME} 
+add_library(${PROJECT_NAME}
   src/model.cpp
   src/srdf_writer.cpp
 )
@@ -44,7 +44,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h"
 )
 
-install(PROGRAMS 
+install(PROGRAMS
   scripts/display_srdf
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(srdfdom)
 
 find_package(Boost REQUIRED)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/test/test.py
+++ b/test/test.py
@@ -69,9 +69,9 @@ def elements_match(a, b):
   return True
 
 def xml_matches(a, b):
-  if isinstance(a, str) or isinstance(a, bytes):
+  if isinstance(a, str):
     return xml_matches(parseString(a).documentElement, b)
-  if isinstance(b, str) or isinstance(b, bytes):
+  if isinstance(b, str):
     return xml_matches(a, parseString(b).documentElement)
   if a.nodeType == xml.dom.Node.DOCUMENT_NODE:
     return xml_matches(a.documentElement, b)

--- a/test/test.py
+++ b/test/test.py
@@ -69,9 +69,9 @@ def elements_match(a, b):
   return True
 
 def xml_matches(a, b):
-  if isinstance(a, str) or isinstance(a, unicode):
+  if isinstance(a, str) or isinstance(a, bytes):
     return xml_matches(parseString(a).documentElement, b)
-  if isinstance(b, str) or isinstance(b, unicode):
+  if isinstance(b, str) or isinstance(b, bytes):
     return xml_matches(a, parseString(b).documentElement)
   if a.nodeType == xml.dom.Node.DOCUMENT_NODE:
     return xml_matches(a.documentElement, b)

--- a/test/test.py
+++ b/test/test.py
@@ -8,6 +8,11 @@ from srdfdom.srdf import SRDF
 from xml.dom.minidom import parseString
 import xml.dom
 
+try:
+  string_types = (str, unicode)
+except NameError:
+  string_types = (str)
+
 # xml match code from test_xacro.py  
 # by Stuart Glaser and William Woodall
 
@@ -69,9 +74,9 @@ def elements_match(a, b):
   return True
 
 def xml_matches(a, b):
-  if isinstance(a, str):
+  if isinstance(a, string_types):
     return xml_matches(parseString(a).documentElement, b)
-  if isinstance(b, str):
+  if isinstance(b, string_types):
     return xml_matches(a, parseString(b).documentElement)
   if a.nodeType == xml.dom.Node.DOCUMENT_NODE:
     return xml_matches(a.documentElement, b)


### PR DESCRIPTION
Following the guidelines to migrate packages to [noetic](http://wiki.ros.org/noetic/Migration)
 - Python3 changes

 - import setup from setuptools instead of distutils-core

 - Bump CMake version to avoid CMP0048 warning
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.