### PR TITLE
Move console_bridge_LIBRARIES to target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(include ${rclcpp_INCLUDE_DIRS}
   ${rmw_implementation_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIR}
   ${TinyXML2_INCLUDE_DIRS}
-  ${console_bridge_INCLUDE_DIRS}
   ${urdfdom_headers_INCLUDE_DIRS}
   ${urdf_INCLUDE_DIRS}
   ${std_msgs_INCLUDE_DIRS}
@@ -36,10 +35,11 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 #System dependencies
-target_link_libraries(${PROJECT_NAME} PUBLIC ${TinyXML2_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${TinyXML2_LIBRARIES})
 
 #Ament dependencies
 ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  console_bridge
   urdfdom_headers
   urdf
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,10 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 #System dependencies
-target_link_libraries(${PROJECT_NAME} PUBLIC ${TinyXML2_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${TinyXML2_LIBRARIES} ${console_bridge_LIBRARIES})
 
 #Ament dependencies
 ament_target_dependencies(${PROJECT_NAME} PUBLIC
-  ${console_bridge_LIBRARIES}
   urdfdom_headers
   urdf
 )
@@ -72,7 +71,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gtest(test_cpp test/srdf_parser_cpp.test test/test_parser.cpp)
-  target_link_libraries(test_cpp ${catkin_LIBRARIES} ${PROJECT_NAME})
+  target_link_libraries(test_cpp ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)


### PR DESCRIPTION
I got the following error when building with Foxy on Ubuntu 20.04.

```
--- stderr: srdfdom                                                                                               
CMake Error at /home/allenh1/ros2_ws/install/ament_cmake_target_dependencies/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:66 (message):
  ament_target_dependencies() the passed package name
  'console_bridge::console_bridge' was not found before
Call Stack (most recent call first):
  CMakeLists.txt:42 (ament_target_dependencies)
```

To fix this, I moved the `${console_bridge_LIBRARIES}` dependency to the `target_link_libraries`, since it is a system library.