### PR TITLE
[fix] export cmake library install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
 )
 
 install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
   DESTINATION lib
 )
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
This fixes an issue with the cmake install that causes problems when using this in an underlay workspace.

When you build this in an underlay and then try to build the overlay repo where something depends on it you get an error like this:

```
--- stderr: moveit_core                          
moveit_core: You did not request a specific build type: Choosing 'Release' for maximum performance
CMake Error at /opt/underlay_ws/install/srdfdom/share/srdfdom/cmake/ament_cmake_export_libraries-extras.cmake:48 (message):
  Package 'srdfdom' exports the library 'srdfdom' which couldn't be found
```

Documentation reference: https://index.ros.org/doc/ros2/Tutorials/Ament-CMake-Documentation/