### PR TITLE
Parse <collision_default> and <enable_collisions> tags

### DIFF
--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -186,8 +186,6 @@ public:
 
     /// The reason why the collision check was disabled/enabled
     std::string reason_;
-
-    bool disabled_;
   };
 
   // Some joints can be passive (not actuated). This structure specifies information about such joints
@@ -209,10 +207,16 @@ public:
     return no_default_collision_links_;
   }
 
-  /// Get the list of pairs of links for which we explicitly disable/enable collision
-  const std::vector<CollisionPair>& getCollisionPairs() const
+  /// Get the list of pairs of links for which we explicitly re-enable collision (after having disabled it via a default)
+  const std::vector<CollisionPair>& getEnabledCollisionPairs() const
   {
-    return collision_pairs_;
+    return enabled_collision_pairs_;
+  }
+
+  /// Get the list of pairs of links for which we explicitly disable collision
+  const std::vector<CollisionPair>& getDisabledCollisionPairs() const
+  {
+    return disabled_collision_pairs_;
   }
 
   /// Get the list of groups defined for this model
@@ -262,7 +266,7 @@ private:
   void loadLinkSphereApproximations(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
   void loadCollisionDefaults(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
   void loadCollisionPairs(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml, const char* tag_name,
-                          bool disabled);
+                          std::vector<CollisionPair>& pairs);
   void loadPassiveJoints(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
 
   std::string name_;
@@ -272,7 +276,8 @@ private:
   std::vector<EndEffector> end_effectors_;
   std::vector<LinkSpheres> link_sphere_approximations_;
   std::vector<std::string> no_default_collision_links_;
-  std::vector<CollisionPair> collision_pairs_;
+  std::vector<CollisionPair> enabled_collision_pairs_;
+  std::vector<CollisionPair> disabled_collision_pairs_;
   std::vector<PassiveJoint> passive_joints_;
 };
 typedef std::shared_ptr<Model> ModelSharedPtr;

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -204,7 +204,7 @@ public:
   }
 
   /// Get the list of links that should have collision checking disabled by default (and only selectively enabled)
-  const std::vector<std::string>& getNoCollisionLinks() const
+  const std::vector<std::string>& getNoDefaultCollisionLinks() const
   {
     return no_default_collision_links_;
   }

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -175,8 +175,8 @@ public:
     std::vector<Sphere> spheres_;
   };
 
-  /// The definition of a disabled collision between two links
-  struct DisabledCollision
+  /// The definition of a disabled/enabled collision between two links
+  struct CollisionPair
   {
     /// The name of the first link (as in URDF) of the disabled collision
     std::string link1_;
@@ -184,8 +184,10 @@ public:
     /// The name of the second link (as in URDF) of the disabled collision
     std::string link2_;
 
-    /// The reason why the collision check was disabled
+    /// The reason why the collision check was disabled/enabled
     std::string reason_;
+
+    bool disabled_;
   };
 
   // Some joints can be passive (not actuated). This structure specifies information about such joints
@@ -201,15 +203,17 @@ public:
     return name_;
   }
 
-  /// Get the list of pairs of links that need not be checked for collisions (because they can never touch given the
-  /// geometry and kinematics of the robot)
-  const std::vector<DisabledCollision>& getDisabledCollisionPairs() const
+  /// Get the list of links that should have collision checking disabled by default (and only selectively enabled)
+  const std::vector<std::string>& getNoCollisionLinks() const
   {
-    return disabled_collisions_;
+    return no_default_collision_links_;
   }
 
-  /// \deprecated{ Use the version returning DisabledCollision }
-  [[deprecated]] std::vector<std::pair<std::string, std::string> > getDisabledCollisions() const;
+  /// Get the list of pairs of links for which we explicitly disable/enable collision
+  const std::vector<CollisionPair>& getCollisionPairs() const
+  {
+    return collision_pairs_;
+  }
 
   /// Get the list of groups defined for this model
   const std::vector<Group>& getGroups() const
@@ -256,7 +260,9 @@ private:
   void loadGroupStates(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
   void loadEndEffectors(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
   void loadLinkSphereApproximations(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
-  void loadDisabledCollisions(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
+  void loadCollisionDefaults(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
+  void loadCollisionPairs(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml, const char* tag_name,
+                          bool disabled);
   void loadPassiveJoints(const urdf::ModelInterface& urdf_model, tinyxml2::XMLElement* robot_xml);
 
   std::string name_;
@@ -265,7 +271,8 @@ private:
   std::vector<VirtualJoint> virtual_joints_;
   std::vector<EndEffector> end_effectors_;
   std::vector<LinkSpheres> link_sphere_approximations_;
-  std::vector<DisabledCollision> disabled_collisions_;
+  std::vector<std::string> no_default_collision_links_;
+  std::vector<CollisionPair> collision_pairs_;
   std::vector<PassiveJoint> passive_joints_;
 };
 typedef std::shared_ptr<Model> ModelSharedPtr;

--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -137,7 +137,7 @@ public:
    *
    * @param root  - TinyXML root element to attach sub elements to
    */
-  void createCollisionPairsXML(tinyxml2::XMLElement* root);
+  void createDisabledCollisionPairsXML(tinyxml2::XMLElement* root);
 
   /**
    * Generate XML for SRDF group states of each joint's position
@@ -173,24 +173,26 @@ protected:
    *
    * @param root  - TinyXML root element to attach sub elements to
    */
-  void createCollisionPairsXML(tinyxml2::XMLElement* root, const char* tag_name, bool disabled);
+  void createCollisionPairsXML(tinyxml2::XMLElement* root, const char* tag_name,
+                               const std::vector<Model::CollisionPair>& pairs);
 
 public:
   // ******************************************************************************************
   // Group Datastructures
   // ******************************************************************************************
 
-  std::vector<srdf::Model::Group> groups_;
-  std::vector<srdf::Model::GroupState> group_states_;
-  std::vector<srdf::Model::VirtualJoint> virtual_joints_;
-  std::vector<srdf::Model::EndEffector> end_effectors_;
-  std::vector<srdf::Model::LinkSpheres> link_sphere_approximations_;
+  std::vector<Model::Group> groups_;
+  std::vector<Model::GroupState> group_states_;
+  std::vector<Model::VirtualJoint> virtual_joints_;
+  std::vector<Model::EndEffector> end_effectors_;
+  std::vector<Model::LinkSpheres> link_sphere_approximations_;
   std::vector<std::string> no_default_collision_links_;
-  std::vector<srdf::Model::CollisionPair> collision_pairs_;
-  std::vector<srdf::Model::PassiveJoint> passive_joints_;
+  std::vector<Model::CollisionPair> disabled_collision_pairs_;
+  std::vector<Model::CollisionPair> enabled_collision_pairs_;
+  std::vector<Model::PassiveJoint> passive_joints_;
 
   // Store the SRDF Model for updating the kinematic_model
-  srdf::ModelSharedPtr srdf_model_;
+  ModelSharedPtr srdf_model_;
 
   // Robot name
   std::string robot_name_;

--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -126,11 +126,18 @@ public:
   void createLinkSphereApproximationsXML(tinyxml2::XMLElement* root);
 
   /**
+   * Generate XML for SRDF collision defaults
+   *
+   * @param root  - TinyXML root element to attach sub elements to
+   */
+  void createCollisionDefaultsXML(tinyxml2::XMLElement* root);
+
+  /**
    * Generate XML for SRDF disabled collisions of robot link pairs
    *
    * @param root  - TinyXML root element to attach sub elements to
    */
-  void createDisabledCollisionsXML(tinyxml2::XMLElement* root);
+  void createCollisionPairsXML(tinyxml2::XMLElement* root);
 
   /**
    * Generate XML for SRDF group states of each joint's position
@@ -160,6 +167,15 @@ public:
    */
   void createPassiveJointsXML(tinyxml2::XMLElement* root);
 
+protected:
+  /**
+   * Generate XML for SRDF disabled/enabled collisions of robot link pairs
+   *
+   * @param root  - TinyXML root element to attach sub elements to
+   */
+  void createCollisionPairsXML(tinyxml2::XMLElement* root, const char* tag_name, bool disabled);
+
+public:
   // ******************************************************************************************
   // Group Datastructures
   // ******************************************************************************************
@@ -169,7 +185,8 @@ public:
   std::vector<srdf::Model::VirtualJoint> virtual_joints_;
   std::vector<srdf::Model::EndEffector> end_effectors_;
   std::vector<srdf::Model::LinkSpheres> link_sphere_approximations_;
-  std::vector<srdf::Model::DisabledCollision> disabled_collisions_;
+  std::vector<std::string> no_default_collision_links_;
+  std::vector<srdf::Model::CollisionPair> collision_pairs_;
   std::vector<srdf::Model::PassiveJoint> passive_joints_;
 
   // Store the SRDF Model for updating the kinematic_model

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -548,7 +548,7 @@ void srdf::Model::loadCollisionDefaults(const urdf::ModelInterface& urdf_model, 
     std::string link = boost::trim_copy(std::string(link_));
     if (!urdf_model.getLink(link))
     {
-      CONSOLE_BRIDGE_logWarn("Link '%s' is not known to URDF. Cannot specify collison default.", link_);
+      CONSOLE_BRIDGE_logWarn("Link '%s' is not known to URDF. Cannot specify collision default.", link_);
       continue;
     }
     std::string value(value_);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -535,14 +535,13 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface& urdf_
 
 void srdf::Model::loadCollisionDefaults(const urdf::ModelInterface& urdf_model, XMLElement* robot_xml)
 {
-  for (XMLElement* xml = robot_xml->FirstChildElement("collision_default"); xml;
-       xml = xml->NextSiblingElement("collision_default"))
+  for (XMLElement* xml = robot_xml->FirstChildElement("disable_default_collisions"); xml;
+       xml = xml->NextSiblingElement("disable_default_collisions"))
   {
     const char* link_ = xml->Attribute("link");
-    const char* value_ = xml->Attribute("allow");
-    if (!link_ || !value_)
+    if (!link_)
     {
-      CONSOLE_BRIDGE_logError("A collision_default tag needs to specify a link name and a allow");
+      CONSOLE_BRIDGE_logError("A disable_default_collisions tag needs to specify a link name");
       continue;
     }
     std::string link = boost::trim_copy(std::string(link_));
@@ -551,11 +550,7 @@ void srdf::Model::loadCollisionDefaults(const urdf::ModelInterface& urdf_model, 
       CONSOLE_BRIDGE_logWarn("Link '%s' is not known to URDF. Cannot specify collision default.", link_);
       continue;
     }
-    std::string value(value_);
-    boost::trim(value);
-    boost::to_upper(value);
-    if (value == "ALWAYS")
-      no_default_collision_links_.push_back(link);
+    no_default_collision_links_.push_back(link);
   }
 }
 

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -350,7 +350,7 @@ void SRDFWriter::createCollisionPairsXML(XMLElement* root, const char* tag_name,
 {
   XMLDocument* doc = root->GetDocument();
 
-  for (const srdf::Model::CollisionPair pair : collision_pairs_)
+  for (const srdf::Model::CollisionPair& pair : collision_pairs_)
   {
     if (pair.disabled_ != disabled)
       continue;

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -333,7 +333,6 @@ void SRDFWriter::createCollisionDefaultsXML(XMLElement* root)
 
   for (const std::string& name : no_default_collision_links_)
   {
-    // Create new element for each link pair
     XMLElement* entry = doc->NewElement("collision_default");
     entry->SetAttribute("link", name.c_str());
     entry->SetAttribute("allow", "ALWAYS");

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -98,7 +98,8 @@ void SRDFWriter::initModel(const urdf::ModelInterface& robot_model, const srdf::
   }
 
   // Copy all read-only data from srdf model to this object
-  disabled_collisions_ = srdf_model_->getDisabledCollisionPairs();
+  no_default_collision_links_ = srdf_model_->getNoCollisionLinks();
+  collision_pairs_ = srdf_model_->getCollisionPairs();
   link_sphere_approximations_ = srdf_model_->getLinkSphereApproximations();
   groups_ = srdf_model_->getGroups();
   virtual_joints_ = srdf_model_->getVirtualJoints();
@@ -195,7 +196,7 @@ void SRDFWriter::generateSRDF(XMLDocument& document)
   createLinkSphereApproximationsXML(robot_root);
 
   // Add Disabled Collisions
-  createDisabledCollisionsXML(robot_root);
+  createCollisionPairsXML(robot_root);
 }
 
 // ******************************************************************************************
@@ -315,32 +316,71 @@ void SRDFWriter::createLinkSphereApproximationsXML(XMLElement* root)
 }
 
 // ******************************************************************************************
-// Generate XML for SRDF disabled collisions of robot link pairs
+// Generate XML for SRDF collision defaults of robot links
 // ******************************************************************************************
-void SRDFWriter::createDisabledCollisionsXML(XMLElement* root)
+void SRDFWriter::createCollisionDefaultsXML(XMLElement* root)
 {
   XMLDocument* doc = root->GetDocument();
 
   // Convenience comments
-  if (disabled_collisions_.size())  // only show comments if there are corresponding elements
+  if (!no_default_collision_links_.empty())  // only show comments if there are corresponding elements
+  {
+    XMLComment* comment = doc->NewComment("DEFAULT COLLISIONS: By default it is assumed that any link of the robot "
+                                          "could potentially come into collision with any other link in the robot. "
+                                          "This tag allows to revert this behavior and disable collisions by default.");
+    root->InsertEndChild(comment);
+  }
+
+  for (const std::string& name : no_default_collision_links_)
+  {
+    // Create new element for each link pair
+    XMLElement* entry = doc->NewElement("collision_default");
+    entry->SetAttribute("link", name.c_str());
+    entry->SetAttribute("allow", "ALWAYS");
+    root->InsertEndChild(entry);
+  }
+  // Write enabled collision pairs
+  createCollisionPairsXML(root, "enable_collisions", false);
+}
+
+// ******************************************************************************************
+// Generate XML for SRDF disabled/enabled collisions of robot link pairs
+// ******************************************************************************************
+void SRDFWriter::createCollisionPairsXML(XMLElement* root, const char* tag_name, bool disabled)
+{
+  XMLDocument* doc = root->GetDocument();
+
+  for (const srdf::Model::CollisionPair pair : collision_pairs_)
+  {
+    if (pair.disabled_ != disabled)
+      continue;
+
+    // Create new element for each link pair
+    XMLElement* entry = doc->NewElement(tag_name);
+    entry->SetAttribute("link1", pair.link1_.c_str());
+    entry->SetAttribute("link2", pair.link2_.c_str());
+    entry->SetAttribute("reason", pair.reason_.c_str());
+
+    root->InsertEndChild(entry);
+  }
+}
+
+// ******************************************************************************************
+// Generate XML for SRDF disabled collisions of robot link pairs
+// ******************************************************************************************
+void SRDFWriter::createCollisionPairsXML(XMLElement* root)
+{
+  XMLDocument* doc = root->GetDocument();
+
+  // Convenience comments
+  if (!collision_pairs_.empty())  // only show comments if there are corresponding elements
   {
     XMLComment* comment = doc->NewComment("DISABLE COLLISIONS: By default it is assumed that any link of the robot "
                                           "could potentially come into collision with any other link in the robot. "
                                           "This tag disables collision checking between a specified pair of links. ");
     root->InsertEndChild(comment);
   }
-
-  for (std::vector<srdf::Model::DisabledCollision>::const_iterator pair_it = disabled_collisions_.begin();
-       pair_it != disabled_collisions_.end(); ++pair_it)
-  {
-    // Create new element for each link pair
-    XMLElement* link_pair = doc->NewElement("disable_collisions");
-    link_pair->SetAttribute("link1", pair_it->link1_.c_str());
-    link_pair->SetAttribute("link2", pair_it->link2_.c_str());
-    link_pair->SetAttribute("reason", pair_it->reason_.c_str());
-
-    root->InsertEndChild(link_pair);
-  }
+  createCollisionPairsXML(root, "disable_collisions", true);
 }
 
 // ******************************************************************************************

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -333,9 +333,8 @@ void SRDFWriter::createCollisionDefaultsXML(XMLElement* root)
 
   for (const std::string& name : no_default_collision_links_)
   {
-    XMLElement* entry = doc->NewElement("collision_default");
+    XMLElement* entry = doc->NewElement("disable_default_collisions");
     entry->SetAttribute("link", name.c_str());
-    entry->SetAttribute("allow", "ALWAYS");
     root->InsertEndChild(entry);
   }
   // Write enabled collision pairs

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -98,7 +98,7 @@ void SRDFWriter::initModel(const urdf::ModelInterface& robot_model, const srdf::
   }
 
   // Copy all read-only data from srdf model to this object
-  no_default_collision_links_ = srdf_model_->getNoCollisionLinks();
+  no_default_collision_links_ = srdf_model_->getNoDefaultCollisionLinks();
   collision_pairs_ = srdf_model_->getCollisionPairs();
   link_sphere_approximations_ = srdf_model_->getLinkSphereApproximations();
   groups_ = srdf_model_->getGroups();

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -93,21 +93,24 @@ TEST(TestCpp, testSimple)
   EXPECT_TRUE(s.getVirtualJoints().size() == 0);
   EXPECT_TRUE(s.getGroups().size() == 0);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getCollisionPairs().empty());
+  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getEnabledCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.2.srdf"));
   EXPECT_TRUE(s.getVirtualJoints().size() == 1);
   EXPECT_TRUE(s.getGroups().size() == 1);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getCollisionPairs().empty());
+  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getEnabledCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.1.srdf"));
   EXPECT_TRUE(s.getVirtualJoints().size() == 0);
   EXPECT_TRUE(s.getGroups().size() == 0);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getCollisionPairs().empty());
+  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getEnabledCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 }
 
@@ -121,8 +124,8 @@ TEST(TestCpp, testComplex)
   EXPECT_TRUE(s.getVirtualJoints().size() == 1);
   EXPECT_TRUE(s.getGroups().size() == 7);
   EXPECT_TRUE(s.getGroupStates().size() == 2);
-  EXPECT_TRUE(s.getCollisionPairs().size() == 2);
-  EXPECT_TRUE(s.getCollisionPairs()[0].reason_ == "adjacent");
+  EXPECT_TRUE(s.getDisabledCollisionPairs().size() == 2);
+  EXPECT_TRUE(s.getDisabledCollisionPairs()[0].reason_ == "adjacent");
   EXPECT_TRUE(s.getEndEffectors().size() == 2);
 
   EXPECT_TRUE(s.getVirtualJoints()[0].name_ == "world_joint");

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -93,21 +93,21 @@ TEST(TestCpp, testSimple)
   EXPECT_TRUE(s.getVirtualJoints().size() == 0);
   EXPECT_TRUE(s.getGroups().size() == 0);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.2.srdf"));
   EXPECT_TRUE(s.getVirtualJoints().size() == 1);
   EXPECT_TRUE(s.getGroups().size() == 1);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 
   EXPECT_TRUE(s.initFile(*u, std::string(TEST_RESOURCE_LOCATION) + "/pr2_desc.1.srdf"));
   EXPECT_TRUE(s.getVirtualJoints().size() == 0);
   EXPECT_TRUE(s.getGroups().size() == 0);
   EXPECT_TRUE(s.getGroupStates().size() == 0);
-  EXPECT_TRUE(s.getDisabledCollisionPairs().empty());
+  EXPECT_TRUE(s.getCollisionPairs().empty());
   EXPECT_TRUE(s.getEndEffectors().size() == 0);
 }
 
@@ -121,8 +121,8 @@ TEST(TestCpp, testComplex)
   EXPECT_TRUE(s.getVirtualJoints().size() == 1);
   EXPECT_TRUE(s.getGroups().size() == 7);
   EXPECT_TRUE(s.getGroupStates().size() == 2);
-  EXPECT_TRUE(s.getDisabledCollisionPairs().size() == 2);
-  EXPECT_TRUE(s.getDisabledCollisionPairs()[0].reason_ == "adjacent");
+  EXPECT_TRUE(s.getCollisionPairs().size() == 2);
+  EXPECT_TRUE(s.getCollisionPairs()[0].reason_ == "adjacent");
   EXPECT_TRUE(s.getEndEffectors().size() == 2);
 
   EXPECT_TRUE(s.getVirtualJoints()[0].name_ == "world_joint");


### PR DESCRIPTION
This PR augments the SRDF XML with tags `<collision_default>` and `<enable_collisions>` to allow specifying ACM defaults for individual links. For example,
```xml
<collision_default link="panda_hand_coarse" allow="ALWAYS" />
<enable_collisions link1="panda_hand_coarse" link2="panda_link0" />
```
UPDATE: See [below](https://github.com/ros-planning/srdfdom/pull/97#pullrequestreview-838696808) for the final xml tags.

will disable collision checking for `panda_hand_coarse` with all other links (particularly newly introduced objects) but enable collision between `panda_hand_coarse` and `panda_link0`.