### PR TITLE
Remove Foxy build jobs

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -16,13 +16,12 @@ jobs:
       matrix:
         env:
           - {
-            ROS_DISTRO: foxy, ROS_REPO: main, CCOV_UPLOAD: true, 
+            ROS_DISTRO: galactic, ROS_REPO: main, CCOV_UPLOAD: true, 
             CLANG_TIDY: pedantic,
             CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'",
             AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov',
             ADDITIONAL_DEBS: 'lcov'
           }
-          - {ROS_DISTRO: foxy, ROS_REPO: testing, CCOV_UPLOAD: false}
           - {ROS_DISTRO: rolling, ROS_REPO: main, CCOV_UPLOAD: false}
           - {ROS_DISTRO: rolling, ROS_REPO: testing, CCOV_UPLOAD: false}
           - {ROS_DISTRO: galactic, ROS_REPO: main, CCOV_UPLOAD: false}


### PR DESCRIPTION
These are not needed anymore with the new foxy branch (#103)