### PR TITLE
Refactor joint properties data structure (#110)

### DIFF
--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -201,19 +201,6 @@ public:
     return name_;
   }
 
-  // Some joints may have additional properties.
-  struct JointProperty
-  {
-    /// The name of the joint that this property belongs to
-    std::string joint_name_;
-
-    /// The name of the property
-    std::string property_name_;
-
-    /// The value of the property. Type not specified.
-    std::string value_;
-  };
-
   /// Get the list of links that should have collision checking disabled by default (and only selectively enabled)
   const std::vector<std::string>& getNoDefaultCollisionLinks() const
   {
@@ -269,20 +256,22 @@ public:
   }
 
   /// Get the joint properties for a particular joint (empty vector if none)
-  const std::vector<JointProperty>& getJointProperties(const std::string& joint_name) const
+  const std::map<std::string, std::string>& getJointProperties(const std::string& joint_name) const
   {
-    std::map<std::string, std::vector<JointProperty>>::const_iterator iter = joint_properties_.find(joint_name);
+    auto iter = joint_properties_.find(joint_name);
+
     if (iter == joint_properties_.end())
     {
-      // We return a standard empty vector here rather than insert a new empty vector
-      // into the map in order to keep the method const
-      return empty_vector_;
+      // We return a standard empty map here rather than create a new empty map
+      // in order to keep the method const
+      return empty_map_;
     }
+
     return iter->second;
   }
 
   /// Get the joint properties list
-  const std::map<std::string, std::vector<JointProperty>>& getJointProperties() const
+  const std::map<std::string, std::map<std::string, std::string>>& getJointProperties() const
   {
     return joint_properties_;
   }
@@ -314,10 +303,12 @@ private:
   std::vector<CollisionPair> enabled_collision_pairs_;
   std::vector<CollisionPair> disabled_collision_pairs_;
   std::vector<PassiveJoint> passive_joints_;
-  std::map<std::string, std::vector<JointProperty>> joint_properties_;
 
-  // Empty joint property vector
-  static const std::vector<JointProperty> empty_vector_;
+  // joint name -> (property name -> property value)
+  std::map<std::string, std::map<std::string, std::string>> joint_properties_;
+
+  // Empty joint property map
+  static const std::map<std::string, std::string> empty_map_;
 };
 typedef std::shared_ptr<Model> ModelSharedPtr;
 typedef std::shared_ptr<const Model> ModelConstSharedPtr;

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -52,6 +52,9 @@ namespace srdf
 class Model
 {
 public:
+  using PropertyMap = std::map<std::string, std::string>;       // property name -> value
+  using JointPropertyMap = std::map<std::string, PropertyMap>;  // joint name -> properties
+
   Model()
   {
   }
@@ -255,23 +258,20 @@ public:
     return link_sphere_approximations_;
   }
 
-  /// Get the joint properties for a particular joint (empty vector if none)
-  const std::map<std::string, std::string>& getJointProperties(const std::string& joint_name) const
+  /// Get the joint properties for a particular joint
+  const PropertyMap& getJointProperties(const std::string& joint_name) const
   {
-    auto iter = joint_properties_.find(joint_name);
+    static const PropertyMap empty_map;
 
-    if (iter == joint_properties_.end())
-    {
-      // We return a standard empty map here rather than create a new empty map
-      // in order to keep the method const
-      return empty_map_;
-    }
-
-    return iter->second;
+    auto it = joint_properties_.find(joint_name);
+    if (it == joint_properties_.end())
+      return empty_map;
+    else
+      return it->second;
   }
 
-  /// Get the joint properties list
-  const std::map<std::string, std::map<std::string, std::string>>& getJointProperties() const
+  /// Get the joint properties map
+  const JointPropertyMap& getJointProperties() const
   {
     return joint_properties_;
   }
@@ -303,12 +303,7 @@ private:
   std::vector<CollisionPair> enabled_collision_pairs_;
   std::vector<CollisionPair> disabled_collision_pairs_;
   std::vector<PassiveJoint> passive_joints_;
-
-  // joint name -> (property name -> property value)
-  std::map<std::string, std::map<std::string, std::string>> joint_properties_;
-
-  // Empty joint property map
-  static const std::map<std::string, std::string> empty_map_;
+  JointPropertyMap joint_properties_;
 };
 typedef std::shared_ptr<Model> ModelSharedPtr;
 typedef std::shared_ptr<const Model> ModelConstSharedPtr;

--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -197,7 +197,7 @@ public:
   std::vector<Model::CollisionPair> disabled_collision_pairs_;
   std::vector<Model::CollisionPair> enabled_collision_pairs_;
   std::vector<Model::PassiveJoint> passive_joints_;
-  std::map<std::string, std::map<std::string, std::string>> joint_properties_;
+  Model::JointPropertyMap joint_properties_;
 
   // Store the SRDF Model for updating the kinematic_model
   ModelSharedPtr srdf_model_;

--- a/include/srdfdom/srdf_writer.h
+++ b/include/srdfdom/srdf_writer.h
@@ -197,7 +197,7 @@ public:
   std::vector<Model::CollisionPair> disabled_collision_pairs_;
   std::vector<Model::CollisionPair> enabled_collision_pairs_;
   std::vector<Model::PassiveJoint> passive_joints_;
-  std::map<std::string, std::vector<srdf::Model::JointProperty>> joint_properties_;
+  std::map<std::string, std::map<std::string, std::string>> joint_properties_;
 
   // Store the SRDF Model for updating the kinematic_model
   ModelSharedPtr srdf_model_;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -45,8 +45,6 @@
 
 using namespace tinyxml2;
 
-const std::map<std::string, std::string> srdf::Model::empty_map_;
-
 bool srdf::Model::isValidJoint(const urdf::ModelInterface& urdf_model, const std::string& name) const
 {
   if (urdf_model.getJoint(name))

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -45,7 +45,7 @@
 
 using namespace tinyxml2;
 
-const std::vector<srdf::Model::JointProperty> srdf::Model::empty_vector_;
+const std::map<std::string, std::string> srdf::Model::empty_map_;
 
 bool srdf::Model::isValidJoint(const urdf::ModelInterface& urdf_model, const std::string& name) const
 {
@@ -612,6 +612,9 @@ void srdf::Model::loadJointProperties(const urdf::ModelInterface& urdf_model, XM
     const char* jname = prop_xml->Attribute("joint_name");
     const char* pname = prop_xml->Attribute("property_name");
     const char* pval = prop_xml->Attribute("value");
+
+    std::string jname_str = boost::trim_copy(std::string(jname));
+
     if (!jname)
     {
       CONSOLE_BRIDGE_logError("joint_property is missing a joint name");
@@ -628,18 +631,13 @@ void srdf::Model::loadJointProperties(const urdf::ModelInterface& urdf_model, XM
       continue;
     }
 
-    JointProperty jp;
-    jp.joint_name_ = boost::trim_copy(std::string(jname));
-    jp.property_name_ = boost::trim_copy(std::string(pname));
-    jp.value_ = std::string(pval);
-
-    if (!isValidJoint(urdf_model, jp.joint_name_))
+    if (!isValidJoint(urdf_model, jname_str))
     {
       CONSOLE_BRIDGE_logError("Property defined for a joint '%s' that is not known to the URDF. Ignoring.",
-                              jp.joint_name_.c_str());
+                              jname_str.c_str());
       continue;
     }
-    joint_properties_[jp.joint_name_].push_back(jp);
+    joint_properties_[jname_str][boost::trim_copy(std::string(pname))] = std::string(pval);
   }
 }
 

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -509,8 +509,7 @@ void SRDFWriter::createJointPropertiesXML(tinyxml2::XMLElement* root)
 
   if (!joint_properties_.empty())
   {
-    XMLComment* comment = doc->NewComment(
-        "JOINT PROPERTIES: Purpose: Define a property for a particular joint (could be a virtual joint)");
+    XMLComment* comment = doc->NewComment("JOINT PROPERTIES: Define properties for individual joints");
     root->InsertEndChild(comment);
   }
   for (const auto& joint_properties : joint_properties_)

--- a/src/srdf_writer.cpp
+++ b/src/srdf_writer.cpp
@@ -518,9 +518,9 @@ void SRDFWriter::createJointPropertiesXML(tinyxml2::XMLElement* root)
     for (const auto& joint_property : joint_properties.second)
     {
       XMLElement* p_joint = doc->NewElement("joint_property");
-      p_joint->SetAttribute("joint_name", joint_property.joint_name_.c_str());
-      p_joint->SetAttribute("property_name", joint_property.property_name_.c_str());
-      p_joint->SetAttribute("value", joint_property.value_.c_str());
+      p_joint->SetAttribute("joint_name", joint_properties.first.c_str());
+      p_joint->SetAttribute("property_name", joint_property.first.c_str());
+      p_joint->SetAttribute("value", joint_property.second.c_str());
       root->InsertEndChild(p_joint);
     }
   }

--- a/test/resources/pr2_desc.3-normalized.srdf
+++ b/test/resources/pr2_desc.3-normalized.srdf
@@ -63,7 +63,7 @@
     <end_effector name="l_end_effector" parent_link="l_wrist_roll_link" group="l_end_effector"/>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="world_joint" type="planar" parent_frame="odom" child_link="base_footprint"/>
-    <!--JOINT PROPERTIES: Purpose: Define a property for a particular joint (could be a virtual joint)-->
+    <!--JOINT PROPERTIES: Define properties for individual joints-->
     <joint_property joint_name="world_joint" property_name="angular_distance_weight" value="0.5"/>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="r_shoulder_pan_link" link2="r_shoulder_lift_link" reason="adjacent"/>

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -179,18 +179,17 @@ TEST(TestCpp, testComplex)
   EXPECT_TRUE(s.getEndEffectors()[index].parent_link_ == "r_wrist_roll_link");
 
   // Joint Properties
-  const std::vector<srdf::Model::JointProperty>& gripper_props = s.getJointProperties("r_gripper_tool_joint");
+  const std::map<std::string, std::string>& gripper_props = s.getJointProperties("r_gripper_tool_joint");
   EXPECT_EQ(gripper_props.size(), 0u);
 
   // When parsing, this made up joint that is not present in the URDF is expected to print an error
   // AND the property should not be made available in the srdf::Model
-  const std::vector<srdf::Model::JointProperty>& made_up_props = s.getJointProperties("made_up_joint");
+  const std::map<std::string, std::string>& made_up_props = s.getJointProperties("made_up_joint");
   EXPECT_EQ(made_up_props.size(), 0u);
 
-  const std::vector<srdf::Model::JointProperty>& world_props = s.getJointProperties("world_joint");
+  const std::map<std::string, std::string>& world_props = s.getJointProperties("world_joint");
   ASSERT_EQ(world_props.size(), 1u);
-  EXPECT_EQ(world_props[0].property_name_, "angular_distance_weight");
-  EXPECT_EQ(world_props[0].value_, "0.5");
+  EXPECT_EQ(world_props.at("angular_distance_weight"), "0.5");
 }
 
 TEST(TestCpp, testReadWrite)

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -179,15 +179,15 @@ TEST(TestCpp, testComplex)
   EXPECT_TRUE(s.getEndEffectors()[index].parent_link_ == "r_wrist_roll_link");
 
   // Joint Properties
-  const std::map<std::string, std::string>& gripper_props = s.getJointProperties("r_gripper_tool_joint");
+  const srdf::Model::PropertyMap& gripper_props = s.getJointProperties("r_gripper_tool_joint");
   EXPECT_EQ(gripper_props.size(), 0u);
 
   // When parsing, this made up joint that is not present in the URDF is expected to print an error
   // AND the property should not be made available in the srdf::Model
-  const std::map<std::string, std::string>& made_up_props = s.getJointProperties("made_up_joint");
+  const srdf::Model::PropertyMap& made_up_props = s.getJointProperties("made_up_joint");
   EXPECT_EQ(made_up_props.size(), 0u);
 
-  const std::map<std::string, std::string>& world_props = s.getJointProperties("world_joint");
+  const srdf::Model::PropertyMap& world_props = s.getJointProperties("world_joint");
   ASSERT_EQ(world_props.size(), 1u);
   EXPECT_EQ(world_props.at("angular_distance_weight"), "0.5");
 }


### PR DESCRIPTION
This PR addresses #110 for Noetic:

- Refactored joint_properties to use a map of maps for streamlined access to joint properties
- Removed JointProperty struct as information contained is redundant.
- Updated tests to account for new signature for `getJointProperties()`.

After doing incorporating these changes, I realized that this would significantly change functionality in the following ways:
- Changed function signatures for `getJointProperties()`
- Removal of `JointProperty` struct

As a result, if this PR gets merged, I will need to update my PR in MoveIt! (https://github.com/ros-planning/moveit/pull/3359) to account for the modified data structures [here](https://github.com/ros-planning/moveit/pull/3359/files#diff-c5eab2d24cfc0cc52d9d0fadc0596533f00ca45e3f8ea45a31bcd8c72b34fafaR386).

Since the backport that I did for ROS1 is relatively new, merging this shouldn't cause many problems, as I doubt anyone else has started using the features I backported 2 weeks ago. 

However, we should be careful about doing the same for ROS2, since it will likely break things in MoveIt2 (such as the same test in MoveIt2 [here](https://github.com/ros-planning/moveit2/blob/2ba82bbf9caf446808ccfcf1041183c952309731/moveit_core/utils/src/robot_model_test_utils.cpp#L383) and as well as anyone else who were relying on the original joint properties data structure/function signatures).

I can definitely work on a similar PR for ROS2, but wanted to get your thoughts first.

Cheers!