### PR TITLE
Update urdf/model.h -> urdf/model.hpp

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -22,14 +22,14 @@ jobs:
             AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov',
             ADDITIONAL_DEBS: 'lcov'
           }
-          - {ROS_DISTRO: humble, ROS_REPO: main, REPO_BRANCH: humble, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: testing, REPO_BRANCH: humble, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: iron, ROS_REPO: main, REPO_BRANCH: iron, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: iron, ROS_REPO: testing, REPO_BRANCH: iron, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: jazzy, ROS_REPO: main, REPO_BRANCH: jazzy, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: jazzy, ROS_REPO: testing, REPO_BRANCH: jazzy, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: rolling, ROS_REPO: main, REPO_BRANCH: ros2, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: rolling, ROS_REPO: testing, REPO_BRANCH: ros2, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: iron, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: rolling, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing, CCOV_UPLOAD: false}
     env:
       CCACHE_DIR: /home/runner/.ccache
       BASEDIR: .base
@@ -39,8 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: ${{ matrix.env.ROS_DISTRO != 'rolling' }}
         with:
-          ref: ${{ matrix.env.REPO_BRANCH }}
+          ref: ${{ matrix.env.ROS_DISTRO }}
+      - uses: actions/checkout@v4
+        if: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
       - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -16,18 +16,20 @@ jobs:
       matrix:
         env:
           - {
-            ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: true,
+            ROS_DISTRO: jazzy, ROS_REPO: main, REPO_BRANCH: jazzy, CCOV_UPLOAD: true,
             CLANG_TIDY: pedantic,
             CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'",
             AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov',
             ADDITIONAL_DEBS: 'lcov'
           }
-          - {ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: iron, ROS_REPO: testing, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: rolling, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: rolling, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: main, REPO_BRANCH: humble, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: testing, REPO_BRANCH: humble, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: iron, ROS_REPO: main, REPO_BRANCH: iron, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: iron, ROS_REPO: testing, REPO_BRANCH: iron, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main, REPO_BRANCH: jazzy, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing, REPO_BRANCH: jazzy, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: rolling, ROS_REPO: main, REPO_BRANCH: ros2, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing, REPO_BRANCH: ros2, CCOV_UPLOAD: false}
     env:
       CCACHE_DIR: /home/runner/.ccache
       BASEDIR: .base
@@ -37,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.env.REPO_BRANCH }}
       - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -16,18 +16,16 @@ jobs:
       matrix:
         env:
           - {
-            ROS_DISTRO: jazzy, ROS_REPO: main, REPO_BRANCH: jazzy, CCOV_UPLOAD: true,
+            ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: true,
             CLANG_TIDY: pedantic,
             CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'",
             AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov',
             ADDITIONAL_DEBS: 'lcov'
           }
-          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
           - {ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: false}
           - {ROS_DISTRO: iron, ROS_REPO: testing, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: jazzy, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: jazzy, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
           - {ROS_DISTRO: rolling, ROS_REPO: main, CCOV_UPLOAD: false}
           - {ROS_DISTRO: rolling, ROS_REPO: testing, CCOV_UPLOAD: false}
     env:

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -39,11 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: ${{ matrix.env.ROS_DISTRO != 'rolling' }}
-        with:
-          ref: ${{ matrix.env.ROS_DISTRO }}
-      - uses: actions/checkout@v4
-        if: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
       - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -41,9 +41,14 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <urdf/model.hpp>
 #include <memory>
 #include <tinyxml2.h>
+
+#if __has_include(<urdf/model.hpp>)
+#include <urdf/model.hpp>
+#else
+#include <urdf/model.h>
+#endif
 
 #include "visibility_control.h"
 

--- a/include/srdfdom/model.h
+++ b/include/srdfdom/model.h
@@ -41,7 +41,7 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include <urdf/model.h>
+#include <urdf/model.hpp>
 #include <memory>
 #include <tinyxml2.h>
 


### PR DESCRIPTION
Seems the deprecation warning came in with a linting PR to the `urdf` repo: https://github.com/ros2/urdf/pull/39