### PR TITLE
Remove `from_parameter_server()` function

### DIFF
--- a/scripts/display_srdf
+++ b/scripts/display_srdf
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import argparse
@@ -10,8 +9,6 @@ parser = argparse.ArgumentParser(usage="Load an SRDF file")
 parser.add_argument(
     "file",
     type=argparse.FileType("r"),
-    nargs="?",
-    default=None,
     help="File to load. Use - for stdin",
 )
 parser.add_argument(
@@ -19,10 +16,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.file is None:
-    robot = SRDF.from_parameter_server()
-else:
-    robot = SRDF.from_xml_string(args.file.read())
+robot = SRDF.from_xml_string(args.file.read())
 
 print(robot)
 

--- a/srdfdom/srdf.py
+++ b/srdfdom/srdf.py
@@ -236,19 +236,6 @@ class Robot(xmlr.Object):
     def add_link_sphere_approximation(self, link):
         self.add_aggregate("link_sphere_approximation", link)
 
-    @classmethod
-    def from_parameter_server(cls, key="robot_description_semantic"):
-        """
-        Retrieve the robot semantic model on the parameter server
-        and parse it to create a SRDF robot structure.
-
-        Warning: this requires roscore to be running.
-        """
-        # Could move this into xml_reflection
-        import rospy
-
-        return cls.from_xml_string(rospy.get_param(key))
-
 
 xmlr.reflect(
     Robot,


### PR DESCRIPTION
There was a function that relied on `rospy` and a ROS parameter server, neither of which exist in ROS 2. So this cleans it up.

Technically, we could re-add something, but it would require either turning the example into an actual ROS node with an SRDF description parameter, or using one of the "unofficial" recreations of the ROS 1 parameter server (i.e., a node with services). Not worth it IMO.

Closes https://github.com/moveit/srdfdom/issues/118