### PR TITLE
Deprecated tinyxml2_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ find_package(console_bridge REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(urdf REQUIRED)
-find_package(tinyxml2_vendor REQUIRED)
-
-# Made available by the vendor package
 find_package(TinyXML2 REQUIRED)
 
 # Set VERSION from package.xml
@@ -84,6 +81,5 @@ ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(console_bridge)
 ament_export_dependencies(urdfdom_headers)
 ament_export_dependencies(urdf)
-ament_export_dependencies(tinyxml2_vendor)
 ament_export_dependencies(TinyXML2)
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -14,18 +14,18 @@
   <url type="bugtracker">https://github.com/ros-planning/srdfdom/issues</url>
   <url type="repository">https://github.com/ros-planning/srdfdom</url>
 
+  <depend>tinyxml2</depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <build_depend>libboost-dev</build_depend>
   <build_depend>console_bridge_vendor</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
-  <build_depend>tinyxml2_vendor</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>urdfdom_headers</build_depend>
 
   <exec_depend>console_bridge_vendor</exec_depend>
   <exec_depend>libconsole-bridge-dev</exec_depend>
-  <exec_depend>tinyxml2_vendor</exec_depend>
+
   <exec_depend>urdf</exec_depend>
   <exec_depend>urdfdom_py</exec_depend>
 


### PR DESCRIPTION
Use "tinyxml2" package instead of deprecated "tinyxml2_vendor"